### PR TITLE
Add MealRecord API

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/controller/MealRecordController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/MealRecordController.java
@@ -1,0 +1,28 @@
+package com.example.tubuhbaru.controller;
+
+import com.example.tubuhbaru.model.MealRecord;
+import com.example.tubuhbaru.service.MealRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+public class MealRecordController {
+    private final MealRecordService service;
+
+    public MealRecordController(MealRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/api/mealRecords")
+    public ResponseEntity<MealRecord> uploadMealRecord(
+            @RequestParam("menuText") String menuText,
+            @RequestParam("image") MultipartFile image) throws IOException {
+        MealRecord record = service.processMeal(image, menuText);
+        return ResponseEntity.ok(record);
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/model/MealRecord.java
+++ b/backend/src/main/java/com/example/tubuhbaru/model/MealRecord.java
@@ -1,0 +1,31 @@
+package com.example.tubuhbaru.model;
+
+public class MealRecord {
+    private final long id;
+    private final String menuText;
+    private final String imageUrl;
+    private final String analysis;
+
+    public MealRecord(long id, String menuText, String imageUrl, String analysis) {
+        this.id = id;
+        this.menuText = menuText;
+        this.imageUrl = imageUrl;
+        this.analysis = analysis;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getMenuText() {
+        return menuText;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getAnalysis() {
+        return analysis;
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/repository/MealRecordRepository.java
+++ b/backend/src/main/java/com/example/tubuhbaru/repository/MealRecordRepository.java
@@ -1,0 +1,24 @@
+package com.example.tubuhbaru.repository;
+
+import com.example.tubuhbaru.model.MealRecord;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class MealRecordRepository {
+    private final List<MealRecord> records = new ArrayList<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    public MealRecord save(String menuText, String imageUrl, String analysis) {
+        MealRecord record = new MealRecord(idGenerator.getAndIncrement(), menuText, imageUrl, analysis);
+        records.add(record);
+        return record;
+    }
+
+    public List<MealRecord> findAll() {
+        return List.copyOf(records);
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/service/MealRecordService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/MealRecordService.java
@@ -1,0 +1,37 @@
+package com.example.tubuhbaru.service;
+
+import com.example.tubuhbaru.model.MealRecord;
+import com.example.tubuhbaru.repository.MealRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+public class MealRecordService {
+    private final MealRecordRepository repository;
+
+    public MealRecordService(MealRecordRepository repository) {
+        this.repository = repository;
+    }
+
+    public MealRecord processMeal(MultipartFile file, String menuText) throws IOException {
+        String imageUrl = uploadToS3(file);
+        String analysis = analyzeMenu(menuText);
+        return repository.save(menuText, imageUrl, analysis);
+    }
+
+    // Stub method that pretends to upload to S3
+    private String uploadToS3(MultipartFile file) throws IOException {
+        String filename = file.getOriginalFilename();
+        long size = file.getSize();
+        // In a real implementation, the file would be uploaded to S3 here
+        return "https://s3.example.com/" + filename;
+    }
+
+    // Stub method that pretends to call ChatGPT API
+    private String analyzeMenu(String menuText) {
+        // In a real implementation, menuText would be sent to the ChatGPT API
+        return "analysis for: " + menuText;
+    }
+}

--- a/backend/src/test/java/com/example/tubuhbaru/service/MealRecordServiceTest.java
+++ b/backend/src/test/java/com/example/tubuhbaru/service/MealRecordServiceTest.java
@@ -1,0 +1,21 @@
+package com.example.tubuhbaru.service;
+
+import com.example.tubuhbaru.repository.MealRecordRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MealRecordServiceTest {
+    @Test
+    void processMealStoresRecord() throws Exception {
+        MealRecordRepository repository = new MealRecordRepository();
+        MealRecordService service = new MealRecordService(repository);
+        MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", new byte[]{1,2,3});
+        var record = service.processMeal(file, "rice and fish");
+        assertEquals("rice and fish", record.getMenuText());
+        assertEquals("https://s3.example.com/test.jpg", record.getImageUrl());
+        assertEquals("analysis for: rice and fish", record.getAnalysis());
+        assertEquals(1, repository.findAll().size());
+    }
+}


### PR DESCRIPTION
## Summary
- add MealRecordController POST API
- create MealRecord model and repository
- add MealRecordService with stubbed S3 upload and ChatGPT analysis
- test MealRecordService

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1b9eeef48331b21c09c220a15e9e