### PR TITLE
Implement meal registration service

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/controller/MealRecordController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/MealRecordController.java
@@ -22,7 +22,7 @@ public class MealRecordController {
     public ResponseEntity<MealRecord> uploadMealRecord(
             @RequestParam("menuText") String menuText,
             @RequestParam("image") MultipartFile image) throws IOException {
-        MealRecord record = service.processMeal(image, menuText);
+        MealRecord record = service.registerMeal(menuText, image);
         return ResponseEntity.ok(record);
     }
 }

--- a/backend/src/main/java/com/example/tubuhbaru/model/MealRecord.java
+++ b/backend/src/main/java/com/example/tubuhbaru/model/MealRecord.java
@@ -1,16 +1,20 @@
 package com.example.tubuhbaru.model;
 
+import java.time.LocalDateTime;
+
 public class MealRecord {
     private final long id;
     private final String menuText;
     private final String imageUrl;
-    private final String analysis;
+    private final String aiComment;
+    private final LocalDateTime createdAt;
 
-    public MealRecord(long id, String menuText, String imageUrl, String analysis) {
+    public MealRecord(long id, String menuText, String imageUrl, String aiComment, LocalDateTime createdAt) {
         this.id = id;
         this.menuText = menuText;
         this.imageUrl = imageUrl;
-        this.analysis = analysis;
+        this.aiComment = aiComment;
+        this.createdAt = createdAt;
     }
 
     public long getId() {
@@ -25,7 +29,11 @@ public class MealRecord {
         return imageUrl;
     }
 
-    public String getAnalysis() {
-        return analysis;
+    public String getAiComment() {
+        return aiComment;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 }

--- a/backend/src/main/java/com/example/tubuhbaru/repository/MealRecordRepository.java
+++ b/backend/src/main/java/com/example/tubuhbaru/repository/MealRecordRepository.java
@@ -3,6 +3,7 @@ package com.example.tubuhbaru.repository;
 import com.example.tubuhbaru.model.MealRecord;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -12,8 +13,8 @@ public class MealRecordRepository {
     private final List<MealRecord> records = new ArrayList<>();
     private final AtomicLong idGenerator = new AtomicLong(1);
 
-    public MealRecord save(String menuText, String imageUrl, String analysis) {
-        MealRecord record = new MealRecord(idGenerator.getAndIncrement(), menuText, imageUrl, analysis);
+    public MealRecord save(String menuText, String imageUrl, String aiComment, LocalDateTime createdAt) {
+        MealRecord record = new MealRecord(idGenerator.getAndIncrement(), menuText, imageUrl, aiComment, createdAt);
         records.add(record);
         return record;
     }

--- a/backend/src/main/java/com/example/tubuhbaru/service/ChatGptService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/ChatGptService.java
@@ -1,0 +1,12 @@
+package com.example.tubuhbaru.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChatGptService {
+    // Stub implementation that mimics calling the ChatGPT API
+    public String getMealFeedback(String menuText) {
+        // In a real implementation, the text would be sent to OpenAI API (gpt-4-turbo)
+        return "analysis for: " + menuText;
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/service/S3Service.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/S3Service.java
@@ -1,0 +1,17 @@
+package com.example.tubuhbaru.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+public class S3Service {
+    // Stub implementation that mimics uploading a file to AWS S3
+    public String uploadImage(MultipartFile file) throws IOException {
+        String filename = file.getOriginalFilename();
+        long size = file.getSize();
+        // In a real implementation, file bytes would be uploaded here
+        return "https://s3.example.com/" + filename;
+    }
+}

--- a/backend/src/test/java/com/example/tubuhbaru/service/MealRecordServiceTest.java
+++ b/backend/src/test/java/com/example/tubuhbaru/service/MealRecordServiceTest.java
@@ -10,12 +10,14 @@ class MealRecordServiceTest {
     @Test
     void processMealStoresRecord() throws Exception {
         MealRecordRepository repository = new MealRecordRepository();
-        MealRecordService service = new MealRecordService(repository);
+        S3Service s3Service = new S3Service();
+        ChatGptService chatGptService = new ChatGptService();
+        MealRecordService service = new MealRecordService(repository, s3Service, chatGptService);
         MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", new byte[]{1,2,3});
-        var record = service.processMeal(file, "rice and fish");
+        var record = service.registerMeal("rice and fish", file);
         assertEquals("rice and fish", record.getMenuText());
         assertEquals("https://s3.example.com/test.jpg", record.getImageUrl());
-        assertEquals("analysis for: rice and fish", record.getAnalysis());
+        assertEquals("analysis for: rice and fish", record.getAiComment());
         assertEquals(1, repository.findAll().size());
     }
 }


### PR DESCRIPTION
## Summary
- add S3Service and ChatGptService stubs
- store AI comment and created time in `MealRecord`
- add `registerMeal` in `MealRecordService`
- wire controller and unit test to new method

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1c402d108331b2060b015b62a964