### PR TITLE
Add axios MealInput view component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.4.0"
+    "vue": "^3.4.0",
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/frontend/src/views/MealInput.vue
+++ b/frontend/src/views/MealInput.vue
@@ -1,0 +1,37 @@
+<template>
+  <form @submit.prevent="submitMeal">
+    <div>
+      <label for="menuText">Menu Text:</label>
+      <input id="menuText" v-model="menuText" required />
+    </div>
+    <div>
+      <label for="image">Image:</label>
+      <input id="image" type="file" @change="onFileChange" required />
+    </div>
+    <button type="submit">Submit</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+
+const menuText = ref('')
+const file = ref(null)
+
+const onFileChange = (e) => {
+  file.value = e.target.files[0]
+}
+
+const submitMeal = async () => {
+  const formData = new FormData()
+  formData.append('menuText', menuText.value)
+  formData.append('image', file.value)
+  try {
+    await axios.post('/api/meals', formData)
+    console.log('アップロード成功')
+  } catch (err) {
+    console.error(err)
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add axios dependency
- create `MealInput.vue` in `views` that posts form data to `/api/meals`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1d2219048331889086acdf695af6