### PR TITLE
Enable meal upload end-to-end

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/tubuhbaru/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.example.tubuhbaru.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/controller/MealsController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/MealsController.java
@@ -1,5 +1,7 @@
 package com.example.tubuhbaru.controller;
 
+import com.example.tubuhbaru.model.MealRecord;
+import com.example.tubuhbaru.service.MealRecordService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -7,18 +9,20 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.Map;
 
 @RestController
 public class MealsController {
+    private final MealRecordService service;
+
+    public MealsController(MealRecordService service) {
+        this.service = service;
+    }
 
     @PostMapping("/api/meals")
-    public ResponseEntity<Map<String, String>> uploadMeal(
+    public ResponseEntity<MealRecord> uploadMeal(
             @RequestParam("menuText") String menuText,
             @RequestParam("image") MultipartFile image) throws IOException {
-        long size = image.getSize();
-        String filename = image.getOriginalFilename();
-        String message = String.format("Received %s (%d bytes) with text '%s'", filename, size, menuText);
-        return ResponseEntity.ok(Map.of("status", "ok", "message", message));
+        MealRecord record = service.registerMeal(menuText, image);
+        return ResponseEntity.ok(record);
     }
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,10 +2,5 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
-  plugins: [vue()],
-  server: {
-    proxy: {
-      '/api': 'http://localhost:8080'
-    }
-  }
+  plugins: [vue()]
 });


### PR DESCRIPTION
## Summary
- configure global CORS for `/api/**`
- wire `/api/meals` endpoint to service
- clean up Vite config so axios calls backend directly

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1db0d328833194ca74098a302c44