### PR TITLE
Update ChatGptService and meal registration logic

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/service/ChatGptService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/ChatGptService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class ChatGptService {
     // Stub implementation that mimics calling the ChatGPT API
-    public String getMealFeedback(String menuText) {
+    public String analyze(String menuText) {
         // In a real implementation, the text would be sent to OpenAI API (gpt-4-turbo)
         return "analysis for: " + menuText;
     }

--- a/backend/src/main/java/com/example/tubuhbaru/service/MealRecordService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/MealRecordService.java
@@ -24,7 +24,7 @@ public class MealRecordService {
 
     public MealRecord registerMeal(String menuText, MultipartFile image) throws IOException {
         String imageUrl = s3Service.uploadImage(image);
-        String aiComment = chatGptService.getMealFeedback(menuText);
+        String aiComment = chatGptService.analyze(menuText);
         LocalDateTime createdAt = LocalDateTime.now();
         return repository.save(menuText, imageUrl, aiComment, createdAt);
     }


### PR DESCRIPTION
## Summary
- switch `ChatGptService` API to `analyze()` method
- update `MealRecordService` to use new `analyze` method

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d1ebb5068833197a604e2c01e37d8