### PR TITLE
Add meal list API and view

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/controller/MealRecordController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/MealRecordController.java
@@ -3,9 +3,7 @@ package com.example.tubuhbaru.controller;
 import com.example.tubuhbaru.model.MealRecord;
 import com.example.tubuhbaru.service.MealRecordService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -24,5 +22,10 @@ public class MealRecordController {
             @RequestParam("image") MultipartFile image) throws IOException {
         MealRecord record = service.registerMeal(menuText, image);
         return ResponseEntity.ok(record);
+    }
+
+    @GetMapping("/api/meals")
+    public ResponseEntity<java.util.List<MealRecord>> getMeals() {
+        return ResponseEntity.ok(service.getAllMeals());
     }
 }

--- a/backend/src/main/java/com/example/tubuhbaru/service/MealRecordService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/MealRecordService.java
@@ -28,4 +28,8 @@ public class MealRecordService {
         LocalDateTime createdAt = LocalDateTime.now();
         return repository.save(menuText, imageUrl, aiComment, createdAt);
     }
+
+    public java.util.List<MealRecord> getAllMeals() {
+        return repository.findAll();
+    }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,11 @@
 <template>
   <h1>TubuhBaru</h1>
   <MealInput />
+  <MealList />
 </template>
 
 <script setup>
 import MealInput from './components/MealInput.vue'
+import MealList from './components/MealList.vue'
 </script>
+

--- a/frontend/src/components/MealList.vue
+++ b/frontend/src/components/MealList.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <div v-for="meal in meals" :key="meal.id" class="meal-card">
+      <img :src="meal.imageUrl" alt="meal image" class="meal-image" />
+      <h3>{{ meal.menuText }}</h3>
+      <p>{{ meal.aiComment }}</p>
+      <small>{{ formatDate(meal.createdAt) }}</small>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+
+const meals = ref([])
+
+const fetchMeals = async () => {
+  const res = await axios.get('/api/meals')
+  meals.value = res.data
+}
+
+onMounted(fetchMeals)
+
+const formatDate = (d) => new Date(d).toLocaleString()
+</script>
+
+<style scoped>
+.meal-card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.meal-image {
+  max-width: 100%;
+  height: auto;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- implement GET `/api/meals` to return all meal records
- expose service method to retrieve meals
- show meal list in frontend via new `MealList.vue`
- update `App.vue` to include meal list component

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1fdec62883319685e94bddaeffad