### PR TITLE
Add weight API and chart

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
@@ -1,0 +1,22 @@
+package com.example.tubuhbaru.controller;
+
+import com.example.tubuhbaru.model.WeightRecord;
+import com.example.tubuhbaru.service.WeightRecordService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class WeightRecordController {
+    private final WeightRecordService service;
+
+    public WeightRecordController(WeightRecordService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/api/weights")
+    public List<WeightRecord> getWeights() {
+        return service.getAllWeights();
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/model/WeightRecord.java
+++ b/backend/src/main/java/com/example/tubuhbaru/model/WeightRecord.java
@@ -1,0 +1,21 @@
+package com.example.tubuhbaru.model;
+
+import java.time.LocalDateTime;
+
+public class WeightRecord {
+    private final double weight;
+    private final LocalDateTime recordedAt;
+
+    public WeightRecord(double weight, LocalDateTime recordedAt) {
+        this.weight = weight;
+        this.recordedAt = recordedAt;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public LocalDateTime getRecordedAt() {
+        return recordedAt;
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/repository/WeightRecordRepository.java
+++ b/backend/src/main/java/com/example/tubuhbaru/repository/WeightRecordRepository.java
@@ -1,0 +1,23 @@
+package com.example.tubuhbaru.repository;
+
+import com.example.tubuhbaru.model.WeightRecord;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class WeightRecordRepository {
+    private final List<WeightRecord> records = new ArrayList<>();
+
+    public WeightRecord save(double weight, LocalDateTime recordedAt) {
+        WeightRecord record = new WeightRecord(weight, recordedAt);
+        records.add(record);
+        return record;
+    }
+
+    public List<WeightRecord> findAll() {
+        return List.copyOf(records);
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/service/WeightRecordService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/WeightRecordService.java
@@ -1,0 +1,26 @@
+package com.example.tubuhbaru.service;
+
+import com.example.tubuhbaru.model.WeightRecord;
+import com.example.tubuhbaru.repository.WeightRecordRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class WeightRecordService {
+    private final WeightRecordRepository repository;
+
+    public WeightRecordService(WeightRecordRepository repository) {
+        this.repository = repository;
+        if (repository.findAll().isEmpty()) {
+            repository.save(70.0, LocalDateTime.now().minusDays(3));
+            repository.save(69.5, LocalDateTime.now().minusDays(2));
+            repository.save(69.0, LocalDateTime.now().minusDays(1));
+        }
+    }
+
+    public List<WeightRecord> getAllWeights() {
+        return repository.findAll();
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "vue": "^3.4.0",
-    "axios": "^1.6.0"
+    "axios": "^1.6.0",
+    "chart.js": "^4.4.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,10 @@
 <template>
   <h1>TubuhBaru</h1>
   <MealInput />
+  <WeightChart />
 </template>
 
 <script setup>
-import MealInput from './components/MealInput.vue'
+import MealInput from './components/MealInput.vue';
+import WeightChart from './components/WeightChart.vue';
 </script>

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -1,0 +1,42 @@
+<template>
+  <canvas ref="canvas"></canvas>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { Chart, registerables } from 'chart.js';
+
+const canvas = ref(null);
+
+onMounted(async () => {
+  const res = await fetch('/api/weights');
+  const data = await res.json();
+
+  Chart.register(...registerables);
+  const ctx = canvas.value.getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: data.map(w => new Date(w.recordedAt).toLocaleDateString()),
+      datasets: [{
+        label: 'Weight',
+        data: data.map(w => w.weight),
+        borderColor: 'blue',
+        tension: 0.3,
+        fill: false
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        x: {
+          display: true
+        },
+        y: {
+          display: true
+        }
+      }
+    }
+  });
+});
+</script>


### PR DESCRIPTION
## Summary
- provide `/api/weights` endpoint to read past weight history
- store simple in-memory weight records
- show a weight transition line chart using Chart.js
- display the chart in the main app
- declare Chart.js dependency for the frontend

## Testing
- `mvn test` *(fails: `mvn: command not found`)*
- `npm install` *(fails: E403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684d1fed14c08331a3dde4e748eb44a8