### PR TITLE
Add weight recording feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The backend exposes:
 
 - `GET /api/hello` – simple hello API returning a JSON message.
 - `POST /api/meals` – accepts `menuText` and an `image` file as multipart form data.
+- `POST /api/weights` – accepts `weight` and `recordedAt` as JSON.
 
 ### Frontend
 
@@ -30,6 +31,7 @@ npm run dev
 ```
 
 The frontend includes a `MealInput` component that posts to `/api/meals`.
+It also provides a `WeightInput` component for sending weights to `/api/weights`.
 
 ### Running Tests
 

--- a/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
@@ -1,0 +1,28 @@
+package com.example.tubuhbaru.controller;
+
+import com.example.tubuhbaru.model.WeightRecord;
+import com.example.tubuhbaru.service.WeightRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+public class WeightRecordController {
+    private final WeightRecordService service;
+
+    public static class WeightRequest {
+        public double weight;
+        public LocalDateTime recordedAt;
+    }
+
+    public WeightRecordController(WeightRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/api/weights")
+    public ResponseEntity<WeightRecord> registerWeight(@RequestBody WeightRequest request) {
+        WeightRecord record = service.registerWeight(request.weight, request.recordedAt);
+        return ResponseEntity.ok(record);
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/model/WeightRecord.java
+++ b/backend/src/main/java/com/example/tubuhbaru/model/WeightRecord.java
@@ -1,0 +1,27 @@
+package com.example.tubuhbaru.model;
+
+import java.time.LocalDateTime;
+
+public class WeightRecord {
+    private final long id;
+    private final double weight;
+    private final LocalDateTime recordedAt;
+
+    public WeightRecord(long id, double weight, LocalDateTime recordedAt) {
+        this.id = id;
+        this.weight = weight;
+        this.recordedAt = recordedAt;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public LocalDateTime getRecordedAt() {
+        return recordedAt;
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/repository/WeightRecordRepository.java
+++ b/backend/src/main/java/com/example/tubuhbaru/repository/WeightRecordRepository.java
@@ -1,0 +1,25 @@
+package com.example.tubuhbaru.repository;
+
+import com.example.tubuhbaru.model.WeightRecord;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class WeightRecordRepository {
+    private final List<WeightRecord> records = new ArrayList<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    public WeightRecord save(double weight, LocalDateTime recordedAt) {
+        WeightRecord record = new WeightRecord(idGenerator.getAndIncrement(), weight, recordedAt);
+        records.add(record);
+        return record;
+    }
+
+    public List<WeightRecord> findAll() {
+        return List.copyOf(records);
+    }
+}

--- a/backend/src/main/java/com/example/tubuhbaru/service/WeightRecordService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/WeightRecordService.java
@@ -1,0 +1,25 @@
+package com.example.tubuhbaru.service;
+
+import com.example.tubuhbaru.model.WeightRecord;
+import com.example.tubuhbaru.repository.WeightRecordRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class WeightRecordService {
+    private final WeightRecordRepository repository;
+
+    public WeightRecordService(WeightRecordRepository repository) {
+        this.repository = repository;
+    }
+
+    public WeightRecord registerWeight(double weight, LocalDateTime recordedAt) {
+        return repository.save(weight, recordedAt);
+    }
+
+    public List<WeightRecord> getAllWeights() {
+        return repository.findAll();
+    }
+}

--- a/backend/src/test/java/com/example/tubuhbaru/service/WeightRecordServiceTest.java
+++ b/backend/src/test/java/com/example/tubuhbaru/service/WeightRecordServiceTest.java
@@ -1,0 +1,21 @@
+package com.example.tubuhbaru.service;
+
+import com.example.tubuhbaru.repository.WeightRecordRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WeightRecordServiceTest {
+    @Test
+    void registerWeightStoresRecord() {
+        WeightRecordRepository repository = new WeightRecordRepository();
+        WeightRecordService service = new WeightRecordService(repository);
+        LocalDateTime t = LocalDateTime.now();
+        var record = service.registerWeight(70.5, t);
+        assertEquals(70.5, record.getWeight());
+        assertEquals(t, record.getRecordedAt());
+        assertEquals(1, repository.findAll().size());
+    }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <h1>TubuhBaru</h1>
+  <WeightInput />
   <MealInput />
   <MealList />
 </template>
@@ -7,5 +8,6 @@
 <script setup>
 import MealInput from './components/MealInput.vue'
 import MealList from './components/MealList.vue'
+import WeightInput from './components/WeightInput.vue'
 </script>
 

--- a/frontend/src/components/WeightInput.vue
+++ b/frontend/src/components/WeightInput.vue
@@ -1,0 +1,22 @@
+<template>
+  <form @submit.prevent="submitWeight">
+    <label for="weight">Weight:</label>
+    <input id="weight" type="number" step="0.1" v-model="weight" required />
+    <button type="submit">Save</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+
+const weight = ref('')
+
+const submitWeight = async () => {
+  await axios.post('/api/weights', {
+    weight: parseFloat(weight.value),
+    recordedAt: new Date().toISOString()
+  })
+  weight.value = ''
+}
+</script>


### PR DESCRIPTION
## Summary
- handle POST `/api/weights` on backend
- store weight and timestamp in memory
- provide `WeightInput.vue` for submitting weights with axios
- show new component in `App.vue`
- document weight endpoint and component

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d21b7b3f483319ba7f14c8727dfe0