### PR TITLE
Add weight chart and weight list API

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
@@ -11,6 +11,16 @@ import java.time.LocalDateTime;
 public class WeightRecordController {
     private final WeightRecordService service;
 
+    public static class WeightResponse {
+        public double weight;
+        public LocalDateTime recordedAt;
+
+        public WeightResponse(double weight, LocalDateTime recordedAt) {
+            this.weight = weight;
+            this.recordedAt = recordedAt;
+        }
+    }
+
     public static class WeightRequest {
         public double weight;
         public LocalDateTime recordedAt;
@@ -24,5 +34,13 @@ public class WeightRecordController {
     public ResponseEntity<WeightRecord> registerWeight(@RequestBody WeightRequest request) {
         WeightRecord record = service.registerWeight(request.weight, request.recordedAt);
         return ResponseEntity.ok(record);
+    }
+
+    @GetMapping("/api/weights")
+    public ResponseEntity<java.util.List<WeightResponse>> getWeights() {
+        var list = service.getAllWeights().stream()
+                .map(r -> new WeightResponse(r.getWeight(), r.getRecordedAt()))
+                .toList();
+        return ResponseEntity.ok(list);
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "vue": "^3.4.0",
-    "axios": "^1.6.0"
+    "axios": "^1.6.0",
+    "chart.js": "^4.4.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <h1>TubuhBaru</h1>
   <WeightInput />
+  <WeightChart />
   <MealInput />
   <MealList />
 </template>
@@ -9,5 +10,6 @@
 import MealInput from './components/MealInput.vue'
 import MealList from './components/MealList.vue'
 import WeightInput from './components/WeightInput.vue'
+import WeightChart from './components/WeightChart.vue'
 </script>
 

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -1,0 +1,39 @@
+<template>
+  <canvas ref="canvas"></canvas>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import axios from 'axios'
+import { Chart } from 'chart.js/auto'
+
+const canvas = ref(null)
+
+const fetchWeights = async () => {
+  const res = await axios.get('/api/weights')
+  return res.data
+}
+
+onMounted(async () => {
+  const weights = await fetchWeights()
+  const labels = weights.map(w => new Date(w.recordedAt).toLocaleDateString())
+  const data = weights.map(w => w.weight)
+
+  new Chart(canvas.value.getContext('2d'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Weight',
+          data,
+          borderColor: 'rgb(75, 192, 192)',
+          fill: false,
+          tension: 0.1
+        }
+      ]
+    }
+  })
+})
+</script>
+


### PR DESCRIPTION
## Summary
- backend: expose GET `/api/weights` to fetch past weight history
- frontend: add Chart.js dependency
- show a new `WeightChart` line graph in the app

## Testing
- `mvn test` *(fails: mvn not found)*
- `npm install` *(fails: network access blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2292f63083318018b25dd4759c6e