### PR TITLE
Add vue-i18n with language switcher

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "vue": "^3.4.0",
     "axios": "^1.6.0",
-    "chart.js": "^4.4.0"
+    "chart.js": "^4.4.0",
+    "vue-i18n": "^9.9.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,13 @@
 <template>
-  <h1>TubuhBaru</h1>
+  <div>
+    <label for="lang-select">Language:</label>
+    <select id="lang-select" v-model="locale">
+      <option value="en">English</option>
+      <option value="ja">日本語</option>
+      <option value="id">Bahasa Indonesia</option>
+    </select>
+  </div>
+  <h1>{{ $t('title') }}</h1>
   <WeightInput />
   <WeightChart />
   <MealInput />
@@ -11,5 +19,8 @@ import MealInput from './components/MealInput.vue'
 import MealList from './components/MealList.vue'
 import WeightInput from './components/WeightInput.vue'
 import WeightChart from './components/WeightChart.vue'
+import { useI18n } from 'vue-i18n'
+
+const { locale } = useI18n()
 </script>
 

--- a/frontend/src/components/MealInput.vue
+++ b/frontend/src/components/MealInput.vue
@@ -1,14 +1,14 @@
 <template>
   <form @submit.prevent="submitMeal">
     <div>
-      <label for="menuText">Menu Text:</label>
+      <label for="menuText">{{ $t('menuTextLabel') }}</label>
       <input id="menuText" v-model="menuText" required />
     </div>
     <div>
-      <label for="image">Image:</label>
+      <label for="image">{{ $t('imageLabel') }}</label>
       <input id="image" type="file" @change="onFileChange" required />
     </div>
-    <button type="submit">Submit</button>
+    <button type="submit">{{ $t('submitButton') }}</button>
   </form>
   <p v-if="message">{{ message }}</p>
 </template>

--- a/frontend/src/components/MealList.vue
+++ b/frontend/src/components/MealList.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <div v-for="meal in meals" :key="meal.id" class="meal-card">
-      <img :src="meal.imageUrl" alt="meal image" class="meal-image" />
+      <div v-for="meal in meals" :key="meal.id" class="meal-card">
+        <img :src="meal.imageUrl" :alt="$t('mealImageAlt')" class="meal-image" />
       <h3>{{ meal.menuText }}</h3>
       <p>{{ meal.aiComment }}</p>
       <small>{{ formatDate(meal.createdAt) }}</small>

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -6,8 +6,10 @@
 import { onMounted, ref } from 'vue'
 import axios from 'axios'
 import { Chart } from 'chart.js/auto'
+import { useI18n } from 'vue-i18n'
 
 const canvas = ref(null)
+const { t } = useI18n()
 
 const fetchWeights = async () => {
   const res = await axios.get('/api/weights')
@@ -24,12 +26,12 @@ onMounted(async () => {
     data: {
       labels,
       datasets: [
-        {
-          label: 'Weight',
-          data,
-          borderColor: 'rgb(75, 192, 192)',
-          fill: false,
-          tension: 0.1
+          {
+            label: t('weightChartLabel'),
+            data,
+            borderColor: 'rgb(75, 192, 192)',
+            fill: false,
+            tension: 0.1
         }
       ]
     }

--- a/frontend/src/components/WeightInput.vue
+++ b/frontend/src/components/WeightInput.vue
@@ -1,8 +1,8 @@
 <template>
   <form @submit.prevent="submitWeight">
-    <label for="weight">Weight:</label>
+    <label for="weight">{{ $t('weightLabel') }}</label>
     <input id="weight" type="number" step="0.1" v-model="weight" required />
-    <button type="submit">Save</button>
+    <button type="submit">{{ $t('saveButton') }}</button>
   </form>
 </template>
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,0 +1,10 @@
+{
+  "title": "TubuhBaru",
+  "menuTextLabel": "Menu Text:",
+  "imageLabel": "Image:",
+  "submitButton": "Submit",
+  "weightLabel": "Weight:",
+  "saveButton": "Save",
+  "mealImageAlt": "meal image",
+  "weightChartLabel": "Weight"
+}

--- a/frontend/src/locales/id.json
+++ b/frontend/src/locales/id.json
@@ -1,0 +1,10 @@
+{
+  "title": "TubuhBaru",
+  "menuTextLabel": "Teks Menu:",
+  "imageLabel": "Gambar:",
+  "submitButton": "Kirim",
+  "weightLabel": "Berat:",
+  "saveButton": "Simpan",
+  "mealImageAlt": "gambar makanan",
+  "weightChartLabel": "Berat"
+}

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -1,0 +1,10 @@
+{
+  "title": "TubuhBaru",
+  "menuTextLabel": "メニュー名:",
+  "imageLabel": "画像:",
+  "submitButton": "送信",
+  "weightLabel": "体重:",
+  "saveButton": "保存",
+  "mealImageAlt": "食事の画像",
+  "weightChartLabel": "体重"
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,14 @@
-import { createApp } from 'vue';
-import App from './App.vue';
+import { createApp } from 'vue'
+import { createI18n } from 'vue-i18n'
+import App from './App.vue'
+import en from './locales/en.json'
+import ja from './locales/ja.json'
+import id from './locales/id.json'
 
-createApp(App).mount('#app');
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en, ja, id }
+})
+
+createApp(App).use(i18n).mount('#app')


### PR DESCRIPTION
## Summary
- install vue-i18n and add locale resources
- configure i18n in `main.js`
- implement language selector in `App.vue`
- localize texts in `MealInput`, `MealList`, `WeightInput`, `WeightChart`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d234e30848331aa7be5d214a3257a