### PR TITLE
Enable Vite dev proxy for Spring Boot API

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,10 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080'
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- connect frontend and backend in dev mode by proxying `/api` requests to Spring Boot

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(no test script / network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e0762231c83318624ec5a40f78e44