### PR TITLE
Fix weight chart auto-update

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,8 +8,8 @@
     </select>
   </div>
   <h1>{{ $t('title') }}</h1>
-  <WeightInput />
-  <WeightChart />
+  <WeightInput @submitted="onWeightAdded" />
+  <WeightChart ref="chart" />
   <MealInput />
   <MealList />
 </template>
@@ -20,7 +20,13 @@ import MealList from './components/MealList.vue'
 import WeightInput from './components/WeightInput.vue'
 import WeightChart from './components/WeightChart.vue'
 import { useI18n } from 'vue-i18n'
+import { ref } from 'vue'
 
 const { locale } = useI18n()
+const chart = ref(null)
+
+const onWeightAdded = () => {
+  chart.value?.renderChart()
+}
 </script>
 

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -9,6 +9,7 @@ import { Chart } from 'chart.js/auto'
 import { useI18n } from 'vue-i18n'
 
 const canvas = ref(null)
+const chart = ref(null)
 const { t } = useI18n()
 
 const fetchWeights = async () => {
@@ -16,26 +17,36 @@ const fetchWeights = async () => {
   return res.data
 }
 
-onMounted(async () => {
+const renderChart = async () => {
   const weights = await fetchWeights()
   const labels = weights.map(w => new Date(w.recordedAt).toLocaleDateString())
   const data = weights.map(w => w.weight)
 
-  new Chart(canvas.value.getContext('2d'), {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-          {
-            label: t('weightChartLabel'),
-            data,
-            borderColor: 'rgb(75, 192, 192)',
-            fill: false,
-            tension: 0.1
-        }
-      ]
-    }
-  })
-})
+  if (chart.value) {
+    chart.value.data.labels = labels
+    chart.value.data.datasets[0].data = data
+    chart.value.update()
+  } else {
+    chart.value = new Chart(canvas.value.getContext('2d'), {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [
+            {
+              label: t('weightChartLabel'),
+              data,
+              borderColor: 'rgb(75, 192, 192)',
+              fill: false,
+              tension: 0.1
+          }
+        ]
+      }
+    })
+  }
+}
+
+onMounted(renderChart)
+
+defineExpose({ renderChart })
 </script>
 

--- a/frontend/src/components/WeightInput.vue
+++ b/frontend/src/components/WeightInput.vue
@@ -9,14 +9,16 @@
 <script setup>
 import { ref } from 'vue'
 import axios from 'axios'
+const emit = defineEmits(['submitted'])
 
 const weight = ref('')
 
 const submitWeight = async () => {
-  await axios.post('/api/weights', {
+  const res = await axios.post('/api/weights', {
     weight: parseFloat(weight.value),
     recordedAt: new Date().toISOString()
   })
   weight.value = ''
+  emit('submitted', res.data)
 }
 </script>


### PR DESCRIPTION
## Summary
- emit a `submitted` event when saving a weight
- expose `renderChart` method from `WeightChart` for refreshing data
- refresh chart from `App.vue` when new weight is recorded

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e17d66b18833186c6f675945a5308