### PR TITLE
Fix weight chart update after saving weight

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -25,8 +25,8 @@ import { ref } from 'vue'
 const { locale } = useI18n()
 const chart = ref(null)
 
-const onWeightAdded = () => {
-  chart.value?.renderChart()
+const onWeightAdded = (record) => {
+  chart.value?.addWeight(record)
 }
 </script>
 

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -10,17 +10,17 @@ import { useI18n } from 'vue-i18n'
 
 const canvas = ref(null)
 const chart = ref(null)
+const weights = ref([])
 const { t } = useI18n()
 
 const fetchWeights = async () => {
   const res = await axios.get('/api/weights')
-  return res.data
+  weights.value = res.data
 }
 
-const renderChart = async () => {
-  const weights = await fetchWeights()
-  const labels = weights.map(w => new Date(w.recordedAt).toLocaleDateString())
-  const data = weights.map(w => w.weight)
+const renderChart = () => {
+  const labels = weights.value.map(w => new Date(w.recordedAt).toLocaleDateString())
+  const data = weights.value.map(w => w.weight)
 
   if (chart.value) {
     chart.value.data.labels = labels
@@ -45,8 +45,18 @@ const renderChart = async () => {
   }
 }
 
-onMounted(renderChart)
+const refreshChart = async () => {
+  await fetchWeights()
+  renderChart()
+}
 
-defineExpose({ renderChart })
+const addWeight = (record) => {
+  weights.value.push(record)
+  renderChart()
+}
+
+onMounted(refreshChart)
+
+defineExpose({ refreshChart, addWeight })
 </script>
 


### PR DESCRIPTION
## Summary
- keep weight records in `WeightChart` and expose `addWeight`
- update `App` to pass new weight record when saved

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e19541200833188b1aa33ec9a85b5