### PR TITLE
Implement live weight updates

### DIFF
--- a/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
+++ b/backend/src/main/java/com/example/tubuhbaru/controller/WeightRecordController.java
@@ -4,6 +4,7 @@ import com.example.tubuhbaru.model.WeightRecord;
 import com.example.tubuhbaru.service.WeightRecordService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
 
@@ -28,6 +29,15 @@ public class WeightRecordController {
 
     public WeightRecordController(WeightRecordService service) {
         this.service = service;
+    }
+
+    @GetMapping("/api/weights/stream")
+    public SseEmitter streamWeights() {
+        SseEmitter emitter = new SseEmitter();
+        service.addEmitter(emitter);
+        emitter.onCompletion(() -> service.removeEmitter(emitter));
+        emitter.onTimeout(() -> service.removeEmitter(emitter));
+        return emitter;
     }
 
     @PostMapping("/api/weights")

--- a/backend/src/main/java/com/example/tubuhbaru/service/WeightRecordService.java
+++ b/backend/src/main/java/com/example/tubuhbaru/service/WeightRecordService.java
@@ -3,6 +3,7 @@ package com.example.tubuhbaru.service;
 import com.example.tubuhbaru.model.WeightRecord;
 import com.example.tubuhbaru.repository.WeightRecordRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,13 +11,31 @@ import java.util.List;
 @Service
 public class WeightRecordService {
     private final WeightRecordRepository repository;
+    private final java.util.List<SseEmitter> emitters = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     public WeightRecordService(WeightRecordRepository repository) {
         this.repository = repository;
     }
 
+    public void addEmitter(SseEmitter emitter) {
+        emitters.add(emitter);
+    }
+
+    public void removeEmitter(SseEmitter emitter) {
+        emitters.remove(emitter);
+    }
+
     public WeightRecord registerWeight(double weight, LocalDateTime recordedAt) {
-        return repository.save(weight, recordedAt);
+        WeightRecord record = repository.save(weight, recordedAt);
+        emitters.forEach(emitter -> {
+            try {
+                emitter.send(record);
+            } catch (Exception e) {
+                emitter.complete();
+                emitters.remove(emitter);
+            }
+        });
+        return record;
     }
 
     public List<WeightRecord> getAllWeights() {

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -50,12 +50,23 @@ const refreshChart = async () => {
   renderChart()
 }
 
+const connectStream = () => {
+  const es = new EventSource('/api/weights/stream')
+  es.onmessage = (e) => {
+    const record = JSON.parse(e.data)
+    addWeight(record)
+  }
+}
+
 const addWeight = (record) => {
   weights.value.push(record)
   renderChart()
 }
 
-onMounted(refreshChart)
+onMounted(() => {
+  refreshChart()
+  connectStream()
+})
 
 defineExpose({ refreshChart, addWeight })
 </script>


### PR DESCRIPTION
## Summary
- stream weight records via SSE on the backend
- expose `/api/weights/stream` endpoint
- connect to the stream from `WeightChart` for realtime updates

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e1a260f1c83319c624a35d05d71f9