### PR TITLE
Fix realtime update for weight chart

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,8 +8,8 @@
     </select>
   </div>
   <h1>{{ $t('title') }}</h1>
-  <WeightInput @submitted="onWeightAdded" />
-  <WeightChart ref="chart" />
+  <WeightInput />
+  <WeightChart />
   <MealInput />
   <MealList />
 </template>
@@ -20,13 +20,7 @@ import MealList from './components/MealList.vue'
 import WeightInput from './components/WeightInput.vue'
 import WeightChart from './components/WeightChart.vue'
 import { useI18n } from 'vue-i18n'
-import { ref } from 'vue'
 
 const { locale } = useI18n()
-const chart = ref(null)
-
-const onWeightAdded = (record) => {
-  chart.value?.addWeight(record)
-}
 </script>
 

--- a/frontend/src/components/WeightInput.vue
+++ b/frontend/src/components/WeightInput.vue
@@ -9,16 +9,24 @@
 <script setup>
 import { ref } from 'vue'
 import axios from 'axios'
+import { useWeightStore } from '../stores/weightStore'
+
 const emit = defineEmits(['submitted'])
+const { addWeight } = useWeightStore()
 
 const weight = ref('')
 
 const submitWeight = async () => {
-  const res = await axios.post('/api/weights', {
-    weight: parseFloat(weight.value),
-    recordedAt: new Date().toISOString()
-  })
-  weight.value = ''
-  emit('submitted', res.data)
+  try {
+    const res = await axios.post('/api/weights', {
+      weight: parseFloat(weight.value),
+      recordedAt: new Date().toISOString()
+    })
+    addWeight(res.data)
+    weight.value = ''
+    emit('submitted', res.data)
+  } catch (err) {
+    console.error('Failed to register weight', err)
+  }
 }
 </script>

--- a/frontend/src/stores/weightStore.js
+++ b/frontend/src/stores/weightStore.js
@@ -1,0 +1,23 @@
+import { reactive } from 'vue'
+import axios from 'axios'
+
+const state = reactive({
+  weights: []
+})
+
+const fetchWeights = async () => {
+  try {
+    const res = await axios.get('/api/weights')
+    state.weights = res.data
+  } catch (err) {
+    console.error('Failed to fetch weights', err)
+  }
+}
+
+const addWeight = (record) => {
+  state.weights.push(record)
+}
+
+export function useWeightStore() {
+  return { state, fetchWeights, addWeight }
+}


### PR DESCRIPTION
## Summary
- add a minimal reactive weightStore
- update WeightInput to register weight in store and log failures
- refactor WeightChart to use weightStore and watch for changes
- simplify App.vue markup

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684e1c3aa48883318d2c2b2e4744b857