### PR TITLE
Trigger weight chart refetch

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,13 +8,14 @@
     </select>
   </div>
   <h1>{{ $t('title') }}</h1>
-  <WeightInput />
-  <WeightChart />
+  <WeightInput @submitted="onWeightSubmitted" />
+  <WeightChart ref="chartRef" />
   <MealInput />
   <MealList />
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import MealInput from './components/MealInput.vue'
 import MealList from './components/MealList.vue'
 import WeightInput from './components/WeightInput.vue'
@@ -22,5 +23,10 @@ import WeightChart from './components/WeightChart.vue'
 import { useI18n } from 'vue-i18n'
 
 const { locale } = useI18n()
+const chartRef = ref(null)
+
+const onWeightSubmitted = () => {
+  chartRef.value?.refetch()
+}
 </script>
 

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -40,7 +40,7 @@ const renderChart = () => {
   }
 }
 
-const refreshChart = async () => {
+const refetch = async () => {
   await fetchWeights()
 }
 
@@ -57,7 +57,7 @@ const addWeight = (record) => {
 }
 
 onMounted(() => {
-  refreshChart()
+  refetch()
   connectStream()
 })
 
@@ -69,6 +69,6 @@ watch(
   { deep: true }
 )
 
-defineExpose({ refreshChart, addWeight })
+defineExpose({ refetch, addWeight })
 </script>
 


### PR DESCRIPTION
## Summary
- expose a `refetch` function from `WeightChart.vue`
- use this `refetch` method when a weight is submitted

## Testing
- `mvn test` *(fails: mvn not found)*
- `npm test` *(fails: npm tries to access network)*

------
https://chatgpt.com/codex/tasks/task_e_684e1d69e3848331a58e01dcebd90c4a