### PR TITLE
Fix weight chart not updating

### DIFF
--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -11,11 +11,11 @@ import { useI18n } from 'vue-i18n'
 const canvas = ref(null)
 const chart = ref(null)
 const { t } = useI18n()
-const { state, fetchWeights, addWeight: storeAddWeight } = useWeightStore()
+const { weights, fetchWeights, addWeight: storeAddWeight } = useWeightStore()
 
 const renderChart = () => {
-  const labels = state.weights.map(w => new Date(w.recordedAt).toLocaleDateString())
-  const data = state.weights.map(w => w.weight)
+  const labels = weights.value.map(w => new Date(w.recordedAt).toLocaleDateString())
+  const data = weights.value.map(w => w.weight)
 
   if (chart.value) {
     chart.value.data.labels = labels
@@ -62,7 +62,7 @@ onMounted(() => {
 })
 
 watch(
-  () => state.weights,
+  () => weights.value,
   () => {
     renderChart()
   },

--- a/frontend/src/components/WeightInput.vue
+++ b/frontend/src/components/WeightInput.vue
@@ -12,7 +12,7 @@ import axios from 'axios'
 import { useWeightStore } from '../stores/weightStore'
 
 const emit = defineEmits(['submitted'])
-const { addWeight } = useWeightStore()
+const { addWeight, fetchWeights } = useWeightStore()
 
 const weight = ref('')
 
@@ -23,6 +23,7 @@ const submitWeight = async () => {
       recordedAt: new Date().toISOString()
     })
     addWeight(res.data)
+    await fetchWeights()
     weight.value = ''
     emit('submitted', res.data)
   } catch (err) {

--- a/frontend/src/stores/weightStore.js
+++ b/frontend/src/stores/weightStore.js
@@ -1,23 +1,21 @@
-import { reactive } from 'vue'
+import { ref } from 'vue'
 import axios from 'axios'
 
-const state = reactive({
-  weights: []
-})
+const weights = ref([])
 
 const fetchWeights = async () => {
   try {
     const res = await axios.get('/api/weights')
-    state.weights = res.data
+    weights.value = res.data
   } catch (err) {
     console.error('Failed to fetch weights', err)
   }
 }
 
 const addWeight = (record) => {
-  state.weights.push(record)
+  weights.value.push(record)
 }
 
 export function useWeightStore() {
-  return { state, fetchWeights, addWeight }
+  return { weights, fetchWeights, addWeight }
 }


### PR DESCRIPTION
## Summary
- refactor weight store to expose `weights` as a reactive ref
- update chart to use the ref and watch for changes
- after submitting weight, fetch the latest list before clearing the form

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1ef743948331a1e093add3d80536